### PR TITLE
Run checkout actions after cart is loaded from session

### DIFF
--- a/affiliatewp-store-credit.php
+++ b/affiliatewp-store-credit.php
@@ -72,7 +72,7 @@ class AffiliateWP_WooCommerce_Credit {
  
 		add_action( 'woocommerce_before_checkout_form', array( $this, 'action_add_checkout_notice' ) );
  
-		add_action( 'init', array( $this, 'checkout_actions' ) );
+		add_action( 'woocommerce_cart_loaded_from_session', array( $this, 'checkout_actions' ) );
  
 		add_action( 'woocommerce_checkout_order_processed', array( $this, 'validate_coupon_usage' ), 10, 2 );
  


### PR DESCRIPTION
When running on init, the cart has not loaded yet. So subtotal, taxes, etc... they are all null. We need to wait until the cart is loaded, there is a handy action JUST for that reason.

Solves #5